### PR TITLE
M60 Changes

### DIFF
--- a/sonorancms/fxmanifest.lua
+++ b/sonorancms/fxmanifest.lua
@@ -4,7 +4,7 @@ games {'gta5'}
 author 'Sonoran Software Systems'
 real_name 'Sonoran CMS FiveM Integration'
 description 'Sonoran CMS to FiveM translation layer'
-version '1.2.9'
+version '1.3.0'
 lua54 'yes'
 
 server_scripts {'server/*.lua', 'config.lua', 'server/util/unzip.js', 'server/util/http.js', 'server/util/sonoran.js', 'server/util/utils.js', '@oxmysql/lib/MySQL.lua', 'server/util/imageHandler.js'}

--- a/sonorancms/server/server.lua
+++ b/sonorancms/server/server.lua
@@ -62,7 +62,7 @@ SetHttpHandler(function(req, res)
 					res.send(json.encode({error = 'Invalid request type'}))
 					return
 				end
-					if not path or path ~= '/upload' then
+				if not path or path ~= '/upload' then
 					res.send(json.encode({error = 'Invalid path'}))
 					return
 				end
@@ -74,7 +74,7 @@ SetHttpHandler(function(req, res)
 				if imageCb then
 					res.send(json.encode({success = true, file = imageCb.error}))
 				else
-					res.send(json.encode({success = false, error = 'Failed to save image. Error: ' ..  imageCb.error}))
+					res.send(json.encode({success = false, error = 'Failed to save image. Error: ' .. imageCb.error}))
 				end
 			end)
 		end
@@ -191,7 +191,7 @@ local function sendConsole(level, color, message)
 		source = info.source:gsub('@@sonorancms/', '') .. ':' .. info.linedefined
 	end
 	local msg = ('[%s][%s:%s%s^7]%s %s^0'):format(time, debugging and source or 'SonoranCMS', color, level, color, message)
-	if (debugging and level == 'DEBUG') or (not debugging and level ~= 'DEBUG') then
+	if (debugging and level == 'DEBUG') or (not debugging and level ~= 'DEBUG') or level == 'ERROR' or level == 'WARNING' or level == 'INFO' then
 		print(msg)
 	end
 	if (level == 'ERROR' or level == 'WARNING') and IsDuplicityVersion() then
@@ -219,6 +219,8 @@ AddEventHandler('SonoranCMS::core:writeLog', function(level, message)
 		infoLog(message)
 	elseif level == 'error' then
 		errorLog(message)
+	elseif level == 'warn' then
+		warnLog(message)
 	else
 		debugLog(message)
 	end

--- a/sonorancms/version.json
+++ b/sonorancms/version.json
@@ -1,4 +1,4 @@
 {
-    "resource": "1.2.9",
+    "resource": "1.3.0",
     "testedFxServerVersion": "5777"
 }


### PR DESCRIPTION
## `gamestate` Changes:
- Added support for `qs-inventory`
- Added graceful handling for `qb-garages` errors
- Changed some `error` logs to `warn` logs 
## `server.lua` Changes:
- Fixed `error`, `warn` & `info` logs not printing unless `debug_mode` was on
- Fixed "Invalid Community ID" error when using the community **uuid** as `CommId` instead of the standard community ID
## Misc Changes:
- Version bump to `1.3.0`